### PR TITLE
Fix typo

### DIFF
--- a/lib/template/.pipedream/pipeline.rb.tt
+++ b/lib/template/.pipedream/pipeline.rb.tt
@@ -6,7 +6,7 @@ stage "Source" do
   )
 end
 
-# IMPORANT: A valid pipeline requires at least 2 stages befre you are able to run
+# IMPORANT: A valid pipeline requires at least 2 stages before you are able to run
 #
 #     pipe deploy
 #


### PR DESCRIPTION
Hi @tongueroo !

I found the typo, so I fixed it. 6bed628.

~Also, buildspec seemed to be broken, so I fixed it. e2e2886
I guess this is because the submodules does not to be fetched and `bundle exec rspec` cannot be executed.~
↑ Sorry, my guess was wrong, so please ignore it here. 
